### PR TITLE
fix the hardcoded dependency on package.json and incorrect use of settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,14 +29,19 @@ class ServerlessLayers {
         .then(() => this.finalizeDeploy())
     }
 
-    const inboundSettings = (serverless.service.custom || {})['serverless-layers'];
+    const inboundSettings = (serverless.service.custom || {})[
+      "serverless-layers"
+    ];
     const defaultSettings = {
-      compileDir: '.serverless',
-      packagePath: path.join(process.env.PWD, `package.json`),
-    }
+      compileDir: ".serverless",
+      packagePath: `package.json`
+    };
 
     this.settings = Object.assign({}, defaultSettings, inboundSettings);
-    this.localPackage = require(defaultSettings.packagePath)
+    this.localPackage = require(path.join(
+      process.env.PWD,
+      this.settings.packagePath
+    ));
   }
 
   getStackName() {


### PR DESCRIPTION
Hello. I was trying to get your project working tonight and was unable to. Along the way I had to account for the fact that the service I'm trying to deploy is nested inside of a root serverless project, so it doesn't have its own package.json. In fixing it I realized that you were accidentally not using the user `settings` object, so I fixed that too.