### PR TITLE
Improve first time setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the plugin to your `serverless.yml` file:
 ```yaml
 provider:
   ...
-  deploymentBucket: #required!
+  deploymentBucket: # OR `layersDeploymentBucket` is required
     name: 'your_bucket'
 
 plugins:
@@ -45,7 +45,7 @@ plugins:
 ```yaml
 custom:
   serverless-layers:
-    packageManager: yarn # NEW
+    packageManager: yarn # OR `npm`
     compileDir: .serverless
     packagePath: package.json
     compatibleRuntimes: ['nodejs']


### PR DESCRIPTION
First of all thanks for the great plugin, just what I was looking for.

I had some minor issue while setting this up on an existing project, where creating a new `layers` only bucket is easier, and got confused with the `#required!` comment, after looking at some of the closed issues I saw I can just define `layersDeploymentBucket` which was more convenient for my projects

Besides that just a suggestion to provide what is the other expected value for `packageManager` as I had to look through the source for it, again a minor issue but might help new comers to the plugin