### PR TITLE
Use stackName from serverless config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ class ServerlessLayers {
   }
 
   getStackName() {
-    return `${this.serverless.service.service}-${this.options.stage}`;
+    return this.provider.naming.getStackName();
   }
 
   getBucketName() {


### PR DESCRIPTION
This should help with keeping naming conventions when users have custom stackName.

BTW thanks so much for this plugin. It was a lifesaver in streamlining deployments.