### PR TITLE
fix error logs when using an old serverless version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ function () {
                 version = this.serverless.getVersion().replace(/\./g, '');
 
                 if (version < 1340) {
-                  this.log("Error: Please install serverless >= 1.34.0 (current ".concat(serverless.getVersion(), ")"));
+                  this.log("Error: Please install serverless >= 1.34.0 (current ".concat(this.serverless.getVersion(), ")"));
                   process.exit(1);
                 }
 


### PR DESCRIPTION
When using an old serverless version we get this message:

```
ReferenceError: serverless is not defined
    at ServerlessLayers._callee$ (.../node_modules/serverless-layers/lib/index.js:92:90)
```
