### PR TITLE
removed if statement with wrong condition

### DIFF
--- a/src/package/Dependencies.js
+++ b/src/package/Dependencies.js
@@ -76,9 +76,7 @@ class Dependencies extends AbstractService {
 
     for (const index in copyBeforeInstall) {
       const filename = copyBeforeInstall[index];
-      if (!fs.existsSync(filename)) {
-        await this.copyProjectFile(filename);
-      }
+      await this.copyProjectFile(filename);
     }
 
     // custom commands


### PR DESCRIPTION
The condition I removed prevented the package-lock.json from being moved to the .serverless/layers/nodejs folder. This caused an error in the package install command that gets executed later. 

Any other package manager should also be impacted by this bug. Unfortunately I don't have time to test them. 

The condition made no sense anyway because the function copyProjectFile already checks if the file exists. 