### PR TITLE
fix not copying files before installation

### DIFF
--- a/src/package/Dependencies.js
+++ b/src/package/Dependencies.js
@@ -76,7 +76,7 @@ class Dependencies extends AbstractService {
 
     for (const index in copyBeforeInstall) {
       const filename = copyBeforeInstall[index];
-      if (!fs.existsSync(filename)) {
+      if (fs.existsSync(filename)) {
         await this.copyProjectFile(filename);
       }
     }


### PR DESCRIPTION
I found that placing the '.npmrc' file in copyBeforeInstall solves my problem with the private repositories but there is a bug in copying the files before installation. This if is never executed when the file exists.