### PR TITLE
Fix issue "TypeError: arn.replace is not a function"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -432,6 +432,10 @@ class ServerlessLayers {
   }
 
   logArn(arn) {
+    if (typeof arn !== 'string') {
+      arn = String(arn);
+    }
+
     let pattern = /arn:aws:lambda:([^:]+):([0-9]+):layer:([^:]+):([0-9]+)/g;
     let region = chalk.bold('$1');
     let name = chalk.magenta('$3');


### PR DESCRIPTION
This is a fix for for issue https://github.com/agutoli/serverless-layers/issues/48

This is a simple fix that test if variable "arn" is of type "String", else convert to string
This object "arn" is only used for login purpose, so converting to String is appropriate in any case

Note: when a layer defined in core serverless is used "arn" is an "Object" (and so this is the root cause of "TypeError: arn.replace is not a function"

