### PR TITLE
bump mkdirp from 0.5.5 to 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fs-copy-file": "^2.1.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^0.5.6",
     "semver": "^7.3.2",
     "slugify": "^1.4.0"
   },


### PR DESCRIPTION
`mkdirp 0.5.5` depends on `minimist 1.2.5` which has a **critical** security issue https://github.com/advisories/GHSA-xvch-5gv4-984h

upgrading to mkdirp 0.5.6 fixes the issue.
