### PR TITLE
Bug fix: check for matching layer version, instead of relying on cloudformation version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-layers",
-  "version": "2.7.0",
+  "version": "2.7.10",
   "description": "",
   "main": "lib/index.js",
   "bugs": {

--- a/src/aws/LayersService.js
+++ b/src/aws/LayersService.js
@@ -2,17 +2,18 @@ const AbstractService = require('../AbstractService');
 
 class LayersService extends AbstractService {
 
-  descriptionWithChecksum (checksum) {
-    return 'created by serverless-layers plugin (' + checksum + ')'
+  descriptionWithVersionKey(versionKey) {
+    return 'created by serverless-layers plugin (' + versionKey + ')'
   }
-  async publishVersion (checksum) {
+
+  async publishVersion(versionKey) {
     const params = {
       Content: {
         S3Bucket: this.bucketName,
         S3Key: this.zipFileKeyName
       },
       LayerName: this.layerName,
-      Description: this.descriptionWithChecksum(checksum),
+      Description: this.descriptionWithVersionKey(versionKey),
 
       CompatibleRuntimes: this.plugin.settings.compatibleRuntimes,
       CompatibleArchitectures: this.plugin.settings.compatibleArchitectures
@@ -26,48 +27,49 @@ class LayersService extends AbstractService {
       });
   }
 
-  async findVersionChecksumInList (checksum, marker) {
+
+  async findVersionChecksumInList(versionKey, marker) {
     const params = {
       LayerName: this.layerName,
-      CompatibleRuntimes: this.plugin.settings.compatibleRuntimes,
-      CompatibleArchitectures: this.plugin.settings.compatibleArchitectures
+      // Question: is layer name specific enough?  Is there a way to deploy multiple runtime architectures per name?
+      // CompatibleRuntime: this.plugin.settings.compatibleRuntimes,
+      // CompatibleArchitecture: this.plugin.settings.compatibleArchitectures
     };
 
-    if (Marker) {
+    if (marker) {
       params.Marker = marker;
     }
 
     const result = await this.awsRequest('Lambda:listLayerVersions', params, { checkError: true });
-    this.plugin.log('Layers returned...');
-    console.log(result);
 
-    const description = this.descriptionWithChecksum(checksum);
+    const description = this.descriptionWithVersionKey(versionKey);
 
     const matchingLayerVersion = result.LayerVersions.find((layer) => layer.Description === description);
     if (matchingLayerVersion) {
       return matchingLayerVersion.LayerVersionArn;
     } else if (result.NextMarker) {
-      return this.findVersionChecksumInList(checksum, result.NextMarker);
+      return this.findVersionChecksumInList(versionKey, result.NextMarker);
     } else {
       return null;
     }
   }
 
-  async checkLayersForChecksum (checksum) {
-    this.plugin.log('Looking for version with...', checksum);
-    const layerVersionArn = await this.findVersionChecksumInList(checksum, marker);
+  async checkLayersForVersionKey(versionKey) {
+    this.plugin.log('Looking for version with "' + versionKey + '"');
+    const layerVersionArn = await this.findVersionChecksumInList(versionKey);
 
     if (layerVersionArn) {
-      const params = { arn: layerVersionArn }
-      const matchingLayerWithContent = await this.awsRequest('Lambda:getLayerVersionByArn', params, { checkError: true });
-      if (matchingLayerWithContent) {
-        this.plugin.log('Matching layer found...', matchingLayerWithContent.Content.CodeSha256);
-        return matchingLayerWithContent.LayerVersionArn;
-      }
+      return layerVersionArn;
+      // TODO: double-check to confirm layer content is as expected
+      //   const params = { arn: layerVersionArn }
+      //   const matchingLayerWithContent = await this.awsRequest('Lambda:getLayerVersionByArn', params, { checkError: true });
+      //   if (matchingLayerWithContent) {
+      //      matchingLayerWithContent.Content.Location // A link to the layer archive in Amazon S3 that is valid for 10 minutes.
+      //   }
     }
   }
 
-  async cleanUpLayers (retainVersions = 0) {
+  async cleanUpLayers(retainVersions = 0) {
     const params = {
       LayerName: this.layerName
     };
@@ -96,7 +98,7 @@ class LayersService extends AbstractService {
     }
   }
 
-  selectVersionsToDelete (versions, retainVersions) {
+  selectVersionsToDelete(versions, retainVersions) {
     return versions
       .sort((a, b) => parseInt(a.Version) === parseInt(b.Version) ? 0 : parseInt(a.Version) > parseInt(b.Version) ? -1 : 1)
       .slice(retainVersions);

--- a/src/runtimes/index.js
+++ b/src/runtimes/index.js
@@ -72,6 +72,10 @@ class Runtimes {
   hasDependenciesChanges() {
     return this._runtime.hasDependenciesChanges();
   }
+
+  getDependenciesChecksum() {
+    return this._runtime.getDependenciesChecksum();
+  }
 }
 
 module.exports = Runtimes;

--- a/src/runtimes/nodejs.js
+++ b/src/runtimes/nodejs.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const crypto = require('crypto');
 
 class NodeJSRuntime {
   constructor(parent, runtime, runtimeDir) {
@@ -9,7 +10,7 @@ class NodeJSRuntime {
       runtime,
       runtimeDir,
       libraryFolder: 'node_modules',
-      packageManager:  'npm',
+      packageManager: 'npm',
       packageManagerExtraArgs: '',
       dependenciesPath: 'package.json',
       compatibleRuntimes: [runtimeDir],
@@ -123,6 +124,10 @@ class NodeJSRuntime {
     }
 
     return isDifferent;
+  }
+
+  getDependenciesChecksum() {
+    return crypto.createHash('md5').update(JSON.stringify(this.localPackage.dependencies)).digest('hex');
   }
 }
 

--- a/src/runtimes/python.js
+++ b/src/runtimes/python.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 class PythonRuntime {
   constructor(parent, runtime, runtimeDir) {
@@ -10,7 +11,7 @@ class PythonRuntime {
       runtime,
       runtimeDir,
       libraryFolder: 'site-packages',
-      packageManager:  'pip',
+      packageManager: 'pip',
       packageManagerExtraArgs: '',
       dependenciesPath: 'requirements.txt',
       compatibleRuntimes: [runtime],
@@ -77,6 +78,10 @@ class PythonRuntime {
     }
 
     return isDifferent;
+  }
+
+  getDependenciesChecksum() {
+    return crypto.createHash('md5').update(JSON.stringify(this.localPackage)).digest('hex');
   }
 }
 

--- a/src/runtimes/ruby.js
+++ b/src/runtimes/ruby.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-
+const crypto = require('crypto');
 
 class RubyRuntime {
   constructor(parent, runtime, runtimeDir) {
@@ -11,7 +11,7 @@ class RubyRuntime {
       runtime,
       runtimeDir,
       libraryFolder: 'gems',
-      packageManager:  'bundle',
+      packageManager: 'bundle',
       packageManagerExtraArgs: '',
       dependenciesPath: 'Gemfile',
       compatibleRuntimes: [runtime],
@@ -85,6 +85,10 @@ class RubyRuntime {
     }
 
     return isDifferent;
+  }
+
+  getDependenciesChecksum() {
+    return crypto.createHash('md5').update(JSON.stringify(this.localPackage)).digest('hex');
   }
 }
 


### PR DESCRIPTION
The intent of this plug-in is to prevent recreation of layers when no updates have occurred (by performing the layer creation outside of the CloudFormation stack). The current logic will rely on the current version of the layer in the CloudFormation stack, when there are no changes in the deployment bucket.  However, this can result in the use of the wrong layer version if the the deployment bucket is updated separately from the CloudFormation stack (either via a `package` command, or a failed stack deployment).  

This update uses the layer description as a "tag" to identify a layer that matches the current dependencies file checksum (and customHash) to ensure that a compatible layer is selected, if available.

Notes:
  * This can, theoretically, lead to multiple layer versions with the same description/"version key" as "different from deployment bucket" is the main trigger for re-buliding a layer.  Reusing a matching layer when the deployment bucket changes is a potential optimization (i.e. find matching checksum if deployment bundle has changed) but a "version key" + retainVersions should be a good start.  Alternately, only using the most-recent layer if the deployment bucket matches may be an appropriate condition for some scenarios.
  * Ideally this would be doing a checksum on the yarn.lock/package-lock.json file to ensure that the installed package versions (not just the dependency list) are identical, which is another potential optimization.