### PR TITLE
Fixed error : failed yarn --production on yarn set version stable

### DIFF
--- a/src/runtimes/nodejs.js
+++ b/src/runtimes/nodejs.js
@@ -59,7 +59,7 @@ class NodeJSRuntime {
 
     this.commands = {
       npm: 'npm install --production --only=prod',
-      yarn: 'yarn --production',
+      yarn: 'yarn workspaces focus --all --production',
       pnpm: 'pnpm install --prod'
     };
   }


### PR DESCRIPTION
The --production flag to yarn install has been removed in Yarn 3, instead you need to use yarn workspaces focus --all --production to avoid installing development dependencies in your production deployment.

I would like it to follow the latest version.
If this is going to be a disruptive change, please consider updating a major version.